### PR TITLE
fixing criteria computation

### DIFF
--- a/joinboostgpu.ipynb
+++ b/joinboostgpu.ipynb
@@ -270,7 +270,7 @@
     "        result = result[result['c'] < tc]\n",
     "        result[\"ts\"] = float(ts)\n",
     "        result[\"tc\"] = float(tc)\n",
-    "        result[\"criteria\"]= result.eval(f\"s*s/c + (ts-s)/(tc -c) * (ts - s)\")\n",
+    "        result = result.reset_index().assign(criteria=result.eval('(s*s/c) + ((ts-s)* (ts - s))/(tc-c)'))\n",
     "        idx = result.groupby(['relation', 'key'])['criteria'].idxmax()\n",
     "        result = result.iloc[idx]\n",
     "\n",


### PR DESCRIPTION
The criteria values were being incorrectly assigned to the wrong rows after computing criteria.
resetting index first before computing and assigning the column.

We can alternatively do
temp = result.eval(...)
result = result.reset_index()
result['criteria'] = temp.